### PR TITLE
bench: add TypeScript

### DIFF
--- a/packages/bench/index.ts
+++ b/packages/bench/index.ts
@@ -1,10 +1,11 @@
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import { transformSync } from '@swc/core'
 import { transform as oxc } from '@oxc-node/core'
 import { Bench } from 'tinybench'
-import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
 
 const bench = new Bench({ time: 1000 })
 
@@ -29,6 +30,17 @@ bench
   })
   .add('oxc', () => {
     oxc('ajax.ts', fixture)
+  })
+  .add('typescript', () => {
+    ts.transpileModule(fixture, {
+      fileName: 'ajax.ts',
+      compilerOptions: {
+        target: ts.ScriptTarget.ESNext,
+        module: ts.ModuleKind.ESNext,
+        isolatedModules: true,
+        sourceMap: true,
+      },
+    })
   })
 
 await bench.warmup() // make results more reliable, ref: https://github.com/tinylibs/tinybench/pull/50

--- a/packages/bench/package.json
+++ b/packages/bench/package.json
@@ -10,6 +10,7 @@
     "@oxc-node/core": "workspace:*",
     "@swc/core": "=1.6.7",
     "tinybench": "^2.8.0",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "typescript": "^5.5.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       tinybench:
         specifier: ^2.8.0
         version: 2.8.0
+      typescript:
+        specifier: ^5.5.3
+        version: 5.5.3
 
   packages/core: {}
 


### PR DESCRIPTION
```

❯ pnpm bench

> oxc-node@0.0.0 bench /Users/brooklyn/workspace/github/oxc-node
> pnpm --filter=bench bench


> bench@0.0.0 bench /Users/brooklyn/workspace/github/oxc-node/packages/bench
> node --import @oxc-node/core/register index.ts

┌─────────┬──────────────┬─────────┬────────────────────┬──────────┬─────────┐
│ (index) │ Task Name    │ ops/sec │ Average Time (ns)  │ Margin   │ Samples │
├─────────┼──────────────┼─────────┼────────────────────┼──────────┼─────────┤
│ 0       │ '@swc/core'  │ '1,539' │ 649450.8402597416  │ '±0.44%' │ 1540    │
│ 1       │ 'oxc'        │ '7,004' │ 142768.56045681832 │ '±0.07%' │ 7005    │
│ 2       │ 'typescript' │ '304'   │ 3284196.5836065547 │ '±2.80%' │ 305     │
└─────────┴──────────────┴─────────┴────────────────────┴──────────┴─────────┘

```
