### PR TITLE
TEST: Test token flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,9 +437,9 @@ checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
 
 [[package]]
 name = "oxc"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6adee1268a2077efca9b1c1f36fdc9d9be2986b70c26bfc648d686002dfc50dd"
+checksum = "36e161476bfc4a98f1b451c11e29ba8bded86013387f619a635c9d201cb07664"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -511,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64a116c5711ab4de5f6780627c9a88a61effc7e918db50a5943472ab5697164"
+checksum = "2ffa6f20cba9bfb3486abc83c438f6a9278e4e030b6e9a16d2b5880132f96a1c"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -525,9 +525,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a801811f4a51678fcb766049a54cf452033240fc7fbe036d356854c7350c9e"
+checksum = "406a3454475f817e71a4b8fc0a92f04e149730bc4c07d0d1803d5fc9ef75c357"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -542,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ce0ae699f31d2b03e251cc54a0226b1e6022bfa2012dc6074d858f23da154c"
+checksum = "d894148693dad702ad668945908f8712fe260c23aaf69bbf9d63a8213a350cdd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -553,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e96d753425812fb3ff3dee311f8b78a333e60fe235f74b99281f3c8bfbb7cd2"
+checksum = "dba3ad9293c9eed98116a01ef008229895d9640d8a1abca12aa54fdc588a62f3"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -565,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_cfg"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e353d71cadac4a92445380e76d511ce95622795e5bf64e0e644b0d71f56621"
+checksum = "4cf77762b883cd93185b9b132c9bb4ad35084bbf3bc75cb8bcb6242c1eb6363c"
 dependencies = [
  "bitflags",
  "itertools",
@@ -580,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_codegen"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b63fa7d6b53b7eb5eabb5d6c62146b2e661199e12ddf9b9849c915d502fec1"
+checksum = "e3add299d3a1b4148e4ab85e59bb5c855fbfb2405a4719aad2a199a802495ba0"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -601,18 +601,18 @@ dependencies = [
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48a633d6f98c3e66c4f46a28f2d6d90b826f66464c7ae74c3ad1c084cb5db4af"
+checksum = "2fc6d1eb979f77be6685a7a67ee5d5124c66ef611c601a84327e7d339db69c41"
 dependencies = [
  "ropey",
 ]
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458d78cc5805fb9496d94b4906afc63a8e4d03cfd293cca8d77c048a1821141f"
+checksum = "33ba161cb61925de34f40b11c1d0d2f20e1894d5333d12f7c455a66244453512"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -620,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1190881a073f992e1b420c7fc9bf7fcdc73b7377a5bc188844873d44ec87e7"
+checksum = "92c1827f0741fae82618b6129c7a3248e8334336879f4968cfce231dd65a9ebf"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -634,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_estree"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78d6c5726456864b42e2ba570e1aceb4fccaef6c98edd2ed2b44ce9f27432373"
+checksum = "c671fd76e9990c90762b7f7f7dd5c3038bf72e3295989b2a71ba11870a193b07"
 
 [[package]]
 name = "oxc_index"
@@ -646,9 +646,9 @@ checksum = "2fa07b0cfa997730afed43705766ef27792873fdf5215b1391949fec678d2392"
 
 [[package]]
 name = "oxc_parser"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec5d7bd6ced861f21f476ef3edca2b2c9b0775696dee4f370614aa06c4d4b767"
+checksum = "959f68446d66542753f2fe081189b729ed89f8ed5302de1a522640ff42eba31e"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -669,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a1d0d251aa32bbc1228cf2e67b016ed9cdb97f2144c2b1027f3dd0fa9d662a"
+checksum = "db7f5710da3fea0f40aaba14d547c61ac30c2840fb5d6a1ea9887766b72310c9"
 dependencies = [
  "oxc_allocator",
  "oxc_ast_macros",
@@ -703,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_semantic"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c1e25e8ce948cdfb8aef182e487074b931e449e7251d2df8442dde559644b8"
+checksum = "425bec6c2ac20ff88573b8fbd87fc67aa97e49de9539979a98bcf79c37011077"
 dependencies = [
  "itertools",
  "oxc_allocator",
@@ -739,9 +739,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04ea95e074243c7ee2f48bb8e7164c6b4f53afb6d1b61dd5d1c521c3c173f3e"
+checksum = "cbc66dc0868f4492562d37733754ef147073410004a44551acb102cf2562f66b"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -752,9 +752,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71f3943f294bacbd1395143ee7d47f19080e35028bd3eaca829f154bd99e3a51"
+checksum = "68bfa728cbbf2161b9afc3325addde64feeb39e8167a0ef1472ad1f0efbc9c48"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -773,15 +773,16 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e9a654a68420c501cd4ec6b2d9fb745c105f98f2e51171445eeaa760fc2208"
+checksum = "69f2919de753ca5ed167d47d12f80173b4c71af607dc6bc6c75769461a505ea4"
 dependencies = [
  "base64",
  "compact_str",
  "cow-utils",
  "indexmap",
  "itoa",
+ "memchr",
  "oxc-browserslist",
  "oxc_allocator",
  "oxc_ast",
@@ -803,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_transformer_plugins"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ef9e92038baf0c082616939e8f7ebd33d9915da225fb27c701e8ac5e4c9bcc1"
+checksum = "aeb7c84df7131f44fe7851d7061036bbb091f92a3348f9a6518ba9694e96a87d"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -825,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_traverse"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afda4da5f89f3b40efe6a6501b3e52cc268508aafc01a0b4c8725c64f58dc492"
+checksum = "528815f5909c4d1237f634f8482600dd08ac9293b3cc7839099f0f7abf327402"
 dependencies = [
  "itoa",
  "oxc_allocator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,8 +438,7 @@ checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
 [[package]]
 name = "oxc"
 version = "0.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e161476bfc4a98f1b451c11e29ba8bded86013387f619a635c9d201cb07664"
+source = "git+https://github.com/oxc-project/oxc.git?branch=05-19-fix_parser_fix_reading_token_flags_on_big-endian_systems#4b28dbc1731d1d78517149d308d19d5e96daa1dd"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -512,8 +511,7 @@ dependencies = [
 [[package]]
 name = "oxc_allocator"
 version = "0.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffa6f20cba9bfb3486abc83c438f6a9278e4e030b6e9a16d2b5880132f96a1c"
+source = "git+https://github.com/oxc-project/oxc.git?branch=05-19-fix_parser_fix_reading_token_flags_on_big-endian_systems#4b28dbc1731d1d78517149d308d19d5e96daa1dd"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -526,8 +524,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast"
 version = "0.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406a3454475f817e71a4b8fc0a92f04e149730bc4c07d0d1803d5fc9ef75c357"
+source = "git+https://github.com/oxc-project/oxc.git?branch=05-19-fix_parser_fix_reading_token_flags_on_big-endian_systems#4b28dbc1731d1d78517149d308d19d5e96daa1dd"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -543,9 +540,9 @@ dependencies = [
 [[package]]
 name = "oxc_ast_macros"
 version = "0.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d894148693dad702ad668945908f8712fe260c23aaf69bbf9d63a8213a350cdd"
+source = "git+https://github.com/oxc-project/oxc.git?branch=05-19-fix_parser_fix_reading_token_flags_on_big-endian_systems#4b28dbc1731d1d78517149d308d19d5e96daa1dd"
 dependencies = [
+ "phf",
  "proc-macro2",
  "quote",
  "syn",
@@ -554,8 +551,7 @@ dependencies = [
 [[package]]
 name = "oxc_ast_visit"
 version = "0.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba3ad9293c9eed98116a01ef008229895d9640d8a1abca12aa54fdc588a62f3"
+source = "git+https://github.com/oxc-project/oxc.git?branch=05-19-fix_parser_fix_reading_token_flags_on_big-endian_systems#4b28dbc1731d1d78517149d308d19d5e96daa1dd"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -566,8 +562,7 @@ dependencies = [
 [[package]]
 name = "oxc_cfg"
 version = "0.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf77762b883cd93185b9b132c9bb4ad35084bbf3bc75cb8bcb6242c1eb6363c"
+source = "git+https://github.com/oxc-project/oxc.git?branch=05-19-fix_parser_fix_reading_token_flags_on_big-endian_systems#4b28dbc1731d1d78517149d308d19d5e96daa1dd"
 dependencies = [
  "bitflags",
  "itertools",
@@ -581,8 +576,7 @@ dependencies = [
 [[package]]
 name = "oxc_codegen"
 version = "0.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3add299d3a1b4148e4ab85e59bb5c855fbfb2405a4719aad2a199a802495ba0"
+source = "git+https://github.com/oxc-project/oxc.git?branch=05-19-fix_parser_fix_reading_token_flags_on_big-endian_systems#4b28dbc1731d1d78517149d308d19d5e96daa1dd"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -602,17 +596,16 @@ dependencies = [
 [[package]]
 name = "oxc_data_structures"
 version = "0.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc6d1eb979f77be6685a7a67ee5d5124c66ef611c601a84327e7d339db69c41"
+source = "git+https://github.com/oxc-project/oxc.git?branch=05-19-fix_parser_fix_reading_token_flags_on_big-endian_systems#4b28dbc1731d1d78517149d308d19d5e96daa1dd"
 dependencies = [
  "ropey",
+ "rustversion",
 ]
 
 [[package]]
 name = "oxc_diagnostics"
 version = "0.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ba161cb61925de34f40b11c1d0d2f20e1894d5333d12f7c455a66244453512"
+source = "git+https://github.com/oxc-project/oxc.git?branch=05-19-fix_parser_fix_reading_token_flags_on_big-endian_systems#4b28dbc1731d1d78517149d308d19d5e96daa1dd"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -621,8 +614,7 @@ dependencies = [
 [[package]]
 name = "oxc_ecmascript"
 version = "0.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c1827f0741fae82618b6129c7a3248e8334336879f4968cfce231dd65a9ebf"
+source = "git+https://github.com/oxc-project/oxc.git?branch=05-19-fix_parser_fix_reading_token_flags_on_big-endian_systems#4b28dbc1731d1d78517149d308d19d5e96daa1dd"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -635,8 +627,7 @@ dependencies = [
 [[package]]
 name = "oxc_estree"
 version = "0.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c671fd76e9990c90762b7f7f7dd5c3038bf72e3295989b2a71ba11870a193b07"
+source = "git+https://github.com/oxc-project/oxc.git?branch=05-19-fix_parser_fix_reading_token_flags_on_big-endian_systems#4b28dbc1731d1d78517149d308d19d5e96daa1dd"
 
 [[package]]
 name = "oxc_index"
@@ -647,8 +638,7 @@ checksum = "2fa07b0cfa997730afed43705766ef27792873fdf5215b1391949fec678d2392"
 [[package]]
 name = "oxc_parser"
 version = "0.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "959f68446d66542753f2fe081189b729ed89f8ed5302de1a522640ff42eba31e"
+source = "git+https://github.com/oxc-project/oxc.git?branch=05-19-fix_parser_fix_reading_token_flags_on_big-endian_systems#4b28dbc1731d1d78517149d308d19d5e96daa1dd"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -670,9 +660,9 @@ dependencies = [
 [[package]]
 name = "oxc_regular_expression"
 version = "0.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7f5710da3fea0f40aaba14d547c61ac30c2840fb5d6a1ea9887766b72310c9"
+source = "git+https://github.com/oxc-project/oxc.git?branch=05-19-fix_parser_fix_reading_token_flags_on_big-endian_systems#4b28dbc1731d1d78517149d308d19d5e96daa1dd"
 dependencies = [
+ "bitflags",
  "oxc_allocator",
  "oxc_ast_macros",
  "oxc_diagnostics",
@@ -704,8 +694,7 @@ dependencies = [
 [[package]]
 name = "oxc_semantic"
 version = "0.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "425bec6c2ac20ff88573b8fbd87fc67aa97e49de9539979a98bcf79c37011077"
+source = "git+https://github.com/oxc-project/oxc.git?branch=05-19-fix_parser_fix_reading_token_flags_on_big-endian_systems#4b28dbc1731d1d78517149d308d19d5e96daa1dd"
 dependencies = [
  "itertools",
  "oxc_allocator",
@@ -740,8 +729,7 @@ dependencies = [
 [[package]]
 name = "oxc_span"
 version = "0.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc66dc0868f4492562d37733754ef147073410004a44551acb102cf2562f66b"
+source = "git+https://github.com/oxc-project/oxc.git?branch=05-19-fix_parser_fix_reading_token_flags_on_big-endian_systems#4b28dbc1731d1d78517149d308d19d5e96daa1dd"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -753,8 +741,7 @@ dependencies = [
 [[package]]
 name = "oxc_syntax"
 version = "0.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68bfa728cbbf2161b9afc3325addde64feeb39e8167a0ef1472ad1f0efbc9c48"
+source = "git+https://github.com/oxc-project/oxc.git?branch=05-19-fix_parser_fix_reading_token_flags_on_big-endian_systems#4b28dbc1731d1d78517149d308d19d5e96daa1dd"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -774,8 +761,7 @@ dependencies = [
 [[package]]
 name = "oxc_transformer"
 version = "0.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f2919de753ca5ed167d47d12f80173b4c71af607dc6bc6c75769461a505ea4"
+source = "git+https://github.com/oxc-project/oxc.git?branch=05-19-fix_parser_fix_reading_token_flags_on_big-endian_systems#4b28dbc1731d1d78517149d308d19d5e96daa1dd"
 dependencies = [
  "base64",
  "compact_str",
@@ -805,8 +791,7 @@ dependencies = [
 [[package]]
 name = "oxc_transformer_plugins"
 version = "0.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeb7c84df7131f44fe7851d7061036bbb091f92a3348f9a6518ba9694e96a87d"
+source = "git+https://github.com/oxc-project/oxc.git?branch=05-19-fix_parser_fix_reading_token_flags_on_big-endian_systems#4b28dbc1731d1d78517149d308d19d5e96daa1dd"
 dependencies = [
  "cow-utils",
  "itoa",
@@ -827,8 +812,7 @@ dependencies = [
 [[package]]
 name = "oxc_traverse"
 version = "0.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528815f5909c4d1237f634f8482600dd08ac9293b3cc7839099f0f7abf327402"
+source = "git+https://github.com/oxc-project/oxc.git?branch=05-19-fix_parser_fix_reading_token_flags_on_big-endian_systems#4b28dbc1731d1d78517149d308d19d5e96daa1dd"
 dependencies = [
  "itoa",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { version = "3.0.0-alpha.33", default-features = false, features = ["serde-json", "napi3"] }
 napi-derive = { version = "3.0.0-alpha.29", default-features = false, features = ["type-def"] }
-oxc = { version = "0.69.0", features = ["codegen", "transformer", "semantic", "regular_expression"] }
+oxc = { version = "0.70.0", features = ["codegen", "transformer", "semantic", "regular_expression"] }
 oxc_resolver = { version = "9.0.0" }
 phf = "0.11"
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { version = "3.0.0-alpha.33", default-features = false, features = ["serde-json", "napi3"] }
 napi-derive = { version = "3.0.0-alpha.29", default-features = false, features = ["type-def"] }
-oxc = { version = "0.70.0", features = ["codegen", "transformer", "semantic", "regular_expression"] }
+oxc = { git = "https://github.com/oxc-project/oxc.git", branch = "05-19-fix_parser_fix_reading_token_flags_on_big-endian_systems", features = ["codegen", "transformer", "semantic", "regular_expression"] }
 oxc_resolver = { version = "9.0.0" }
 phf = "0.11"
 serde_json = "1"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@napi-rs/wasm-runtime": "^0.2.6",
     "@oxc-node/cli": "workspace:*",
     "@oxc-node/core": "workspace:*",
-    "@oxc-project/runtime": "^0.69.0",
+    "@oxc-project/runtime": "^0.70.0",
     "@types/node": "^22.10.7",
     "ava": "^6.2.0",
     "cross-env": "^7.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "3.0.0-alpha.79",
-    "@oxc-project/runtime": "^0.69.0"
+    "@oxc-project/runtime": "^0.70.0"
   },
   "dependencies": {
     "pirates": "^4.0.7"

--- a/packages/integrate-module-bundler/package.json
+++ b/packages/integrate-module-bundler/package.json
@@ -17,7 +17,7 @@
     "@nestjs/core": "^11.0.12",
     "@nestjs/platform-express": "^11.0.12",
     "@oxc-node/cli": "workspace:*",
-    "@oxc-project/runtime": "^0.69.0",
+    "@oxc-project/runtime": "^0.70.0",
     "@types/express": "^5.0.1",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: workspace:*
         version: link:packages/core
       '@oxc-project/runtime':
-        specifier: ^0.69.0
-        version: 0.69.0
+        specifier: ^0.70.0
+        version: 0.70.0
       '@types/node':
         specifier: ^22.10.7
         version: 22.15.18
@@ -89,7 +89,7 @@ importers:
         version: 4.0.0-rc.4(typanion@3.14.0)
       rolldown:
         specifier: ^1.0.0-beta.8
-        version: 1.0.0-beta.8(@oxc-project/runtime@0.69.0)(typescript@5.8.3)
+        version: 1.0.0-beta.8(@oxc-project/runtime@0.70.0)(typescript@5.8.3)
 
   packages/core:
     dependencies:
@@ -101,8 +101,8 @@ importers:
         specifier: 3.0.0-alpha.79
         version: 3.0.0-alpha.79(@emnapi/runtime@1.4.3)(@types/node@22.15.18)(emnapi@1.4.3)
       '@oxc-project/runtime':
-        specifier: ^0.69.0
-        version: 0.69.0
+        specifier: ^0.70.0
+        version: 0.70.0
 
   packages/integrate-ava:
     devDependencies:
@@ -190,8 +190,8 @@ importers:
         specifier: workspace:*
         version: link:../cli
       '@oxc-project/runtime':
-        specifier: ^0.69.0
-        version: 0.69.0
+        specifier: ^0.70.0
+        version: 0.70.0
       '@types/express':
         specifier: ^5.0.1
         version: 5.0.2
@@ -1224,8 +1224,8 @@ packages:
   '@octokit/types@14.0.0':
     resolution: {integrity: sha512-VVmZP0lEhbo2O1pdq63gZFiGCKkm8PPp8AUOijlwPO6hojEVjspA0MWKP7E4hbvGxzFKNqKr6p0IYtOH/Wf/zA==}
 
-  '@oxc-project/runtime@0.69.0':
-    resolution: {integrity: sha512-v4WCEJEktTuWY+DEaR1XNITKZD9S0BCyoBeCTyHUH3ppgrb4IlMeDTkwNyfvaIXBFfhlCX4DI445TJ4cqiK0FA==}
+  '@oxc-project/runtime@0.70.0':
+    resolution: {integrity: sha512-+OV+5OQ2/KFSamt9hecuQ682AB06QwMfEQHrko1v98zF3kWAOp1+CAc3P27mtEPQPMQvRR1d1BYE6BTijbcxzQ==}
     engines: {node: '>=6.9.0'}
 
   '@oxc-project/types@0.65.0':
@@ -5222,7 +5222,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 25.0.0
 
-  '@oxc-project/runtime@0.69.0': {}
+  '@oxc-project/runtime@0.70.0': {}
 
   '@oxc-project/types@0.65.0': {}
 
@@ -7742,14 +7742,14 @@ snapshots:
     dependencies:
       glob: 9.3.5
 
-  rolldown@1.0.0-beta.8(@oxc-project/runtime@0.69.0)(typescript@5.8.3):
+  rolldown@1.0.0-beta.8(@oxc-project/runtime@0.70.0)(typescript@5.8.3):
     dependencies:
       '@oxc-project/types': 0.65.0
       '@valibot/to-json-schema': 1.0.0(valibot@1.0.0(typescript@5.8.3))
       ansis: 3.17.0
       valibot: 1.0.0(typescript@5.8.3)
     optionalDependencies:
-      '@oxc-project/runtime': 0.69.0
+      '@oxc-project/runtime': 0.70.0
       '@rolldown/binding-darwin-arm64': 1.0.0-beta.8
       '@rolldown/binding-darwin-x64': 1.0.0-beta.8
       '@rolldown/binding-freebsd-x64': 1.0.0-beta.8


### PR DESCRIPTION
Check that https://github.com/oxc-project/oxc/pull/11153 fixes build on `s390x` (big endian).