### PR TITLE
feat: add top level `transform` and `transformAsync` back

### DIFF
--- a/packages/bench/index.ts
+++ b/packages/bench/index.ts
@@ -53,7 +53,6 @@ bench
     })
   })
 
-await bench.warmup() // make results more reliable, ref: https://github.com/tinylibs/tinybench/pull/50
 await bench.run()
 
 console.table(bench.table())

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -13,8 +13,12 @@ export declare class Output {
   sourceMap(): string | null
 }
 
+export function transform(path: string, source: string | Uint8Array): Output
+
+export function transformAsync(path: string, source: string | Uint8Array): Promise<Output>
+
 export declare class OxcTransformer {
-  constructor(cwd: string)
+  constructor(cwd?: string)
   transform(path: string, source: string | Uint8Array): Output
   transformAsync(path: string, source: string | Uint8Array | Buffer): Promise<Output>
 }

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -376,6 +376,8 @@ if (!nativeBinding) {
 
 module.exports = nativeBinding
 module.exports.Output = nativeBinding.Output
+module.exports.transform = nativeBinding.transform
+module.exports.transformAsync = nativeBinding.transformAsync
 module.exports.OxcTransformer = nativeBinding.OxcTransformer
 module.exports.createResolve = nativeBinding.createResolve
 module.exports.initTracing = nativeBinding.initTracing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,21 @@ impl Output {
     }
 }
 
+#[napi]
+pub fn transform(path: String, source: Either<String, &[u8]>) -> Result<Output> {
+    let transformer = OxcTransformer::new(None);
+    transformer.transform(path, source)
+}
+
+#[napi]
+pub fn transform_async(
+    path: String,
+    source: Either3<String, Uint8Array, Buffer>,
+) -> AsyncTask<TransformTask> {
+    let transformer = OxcTransformer::new(None);
+    transformer.transform_async(path, source)
+}
+
 pub struct TransformTask {
     cwd: String,
     path: String,
@@ -211,8 +226,15 @@ pub struct OxcTransformer {
 #[napi]
 impl OxcTransformer {
     #[napi(constructor)]
-    pub fn new(cwd: String) -> Self {
-        Self { cwd }
+    pub fn new(cwd: Option<String>) -> Self {
+        Self {
+            cwd: match cwd {
+                Some(cwd) => cwd,
+                None => env::current_dir()
+                    .map(|p| p.to_string_lossy().to_string())
+                    .unwrap(),
+            },
+        }
     }
 
     #[napi]


### PR DESCRIPTION
`cwd` in `constructor` should be optional.

`bench.warmup()` is unavailable anymore in latest `tinybench`.