### PR TITLE
chore: mark crate as unpublished

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "oxc-node"
 version = "0.0.0"
 authors = ["LongYinan <github@lyn.one>"]
 edition = "2024"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
## Summary
- Add `publish = false` to the Cargo package metadata so the crate cannot be published to a registry.

## Verification
- `cargo metadata --no-deps --format-version 1`