### PR TITLE
fix: migrate from deprecated module.register() to module.registerHooks()

### DIFF
--- a/packages/core/register.mjs
+++ b/packages/core/register.mjs
@@ -3,9 +3,9 @@ import * as NodeModule from "node:module";
 import { addHook } from "pirates";
 
 import { OxcTransformer } from "./index.js";
+import { createResolve, initTracing, load } from "./index.js";
 
-// Destructure from NodeModule namespace to support older Node.js versions
-const { register, setSourceMapsSupport } = NodeModule;
+const { registerHooks, register, setSourceMapsSupport } = NodeModule;
 
 const DEFAULT_EXTENSIONS = new Set([
   ".js",
@@ -20,7 +20,25 @@ const DEFAULT_EXTENSIONS = new Set([
   ".es",
 ]);
 
-register("@oxc-node/core/esm", import.meta.url);
+// Use registerHooks (Node.js >= 24.4) when available, fall back to deprecated register()
+if (typeof registerHooks === "function") {
+  initTracing();
+
+  // Wrap resolve to strip fields not recognized by the native binding
+  function resolve(specifier, context, nextResolve) {
+    const { parentURL, conditions } = context;
+    return createResolve(
+      { getCurrentDirectory: () => process.cwd() },
+      specifier,
+      { parentURL, conditions },
+      nextResolve,
+    );
+  }
+
+  registerHooks({ resolve, load });
+} else {
+  register("@oxc-node/core/esm", import.meta.url);
+}
 
 if (typeof setSourceMapsSupport === "function") {
   setSourceMapsSupport(true, { nodeModules: true, generatedCode: true });


### PR DESCRIPTION
## Summary

`module.register()` has been runtime-deprecated as [DEP0205](https://nodejs.org/api/deprecations.html#DEP0205) since Node.js v25.9.0 (see [nodejs/node#62401](https://github.com/nodejs/node/pull/62401)), causing the following warning on every invocation:

```
(node:18283) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
```

## Changes

- Use `module.registerHooks()` when available (Node.js >= 24.4), falling back to `module.register()` for older versions
- The `resolve` hook is wrapped to only pass `parentURL` and `conditions` to the native `createResolve` binding, stripping newer context fields (e.g. `importAttributes`) that the native binding doesn't recognize
- `initTracing()` is called directly in the `registerHooks` branch since `esm.mjs` is no longer imported in that path

## Note for maintainers

This workaround strips unknown fields from the resolve context before passing to the native binding. A more robust long-term fix would be to update the Rust `createResolve` implementation to either:

1. Accept and ignore unknown fields in the context object (using `#[napi(object)]` with `#[serde(flatten)]` or similar), or
2. Explicitly support `importAttributes` (and any future fields Node.js adds to the resolve context)

This would make the native binding forward-compatible with future Node.js versions without needing a JS wrapper.