### PR TITLE
chore: update packageManager to pnpm 11.0.4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: pnpm
       - name: Install dependencies
         run: pnpm install
       - name: Lint
@@ -58,7 +57,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: pnpm
       - name: Install dependencies
         run: pnpm install
       - name: Build
@@ -146,7 +144,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: pnpm
       - name: Install
         run: rustup target add ${{ matrix.settings.target }}
       - uses: oxc-project/setup-rust@23f38cfb0c04af97a055f76acee94d5be71c7c82 # v1.0.16
@@ -177,7 +174,6 @@ jobs:
         if: matrix.settings.target == 'i686-pc-windows-msvc'
         with:
           node-version: 22
-          cache: pnpm
           architecture: x86
       - name: Build
         run: ${{ matrix.settings.build }}
@@ -229,7 +225,8 @@ jobs:
             pnpm --filter=@oxc-node/core build --target x86_64-unknown-freebsd
             pnpm --filter=@oxc-node/core export-oxc-runtime
             pnpm --filter @oxc-node/cli build
-            pnpm rebuild
+            # Re-link workspace bins after the CLI entrypoint is generated.
+            pnpm install --offline --ignore-scripts
             pnpm test
             rm -rf node_modules
             rm -rf target
@@ -283,7 +280,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node }}
-          cache: pnpm
           check-latest: true
           architecture: ${{ matrix.settings.architecture }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -339,7 +335,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node }}
-          cache: pnpm
       - name: Output docker params
         id: docker
         run: |
@@ -411,7 +406,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: pnpm
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: cli
@@ -452,7 +446,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: pnpm
       - name: Install dependencies
         run: pnpm install
       - name: Download all artifacts

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -172,6 +172,8 @@ jobs:
         shell: bash
       - name: Install dependencies
         run: pnpm install
+      - name: Pin cargo binary
+        run: echo "CARGO=$(rustup which cargo)" >> "$GITHUB_ENV"
       - name: Setup node x86
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         if: matrix.settings.target == 'i686-pc-windows-msvc'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
+          package-manager-cache: false
       - name: Install dependencies
         run: pnpm install
       - name: Lint
@@ -57,6 +58,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
+          package-manager-cache: false
       - name: Install dependencies
         run: pnpm install
       - name: Build
@@ -144,12 +146,13 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-      - name: Install
-        run: rustup target add ${{ matrix.settings.target }}
+          package-manager-cache: false
       - uses: oxc-project/setup-rust@23f38cfb0c04af97a055f76acee94d5be71c7c82 # v1.0.16
         with:
           cache-key: ${{ matrix.settings.target }}-${{ matrix.settings.host }}
           save-cache: ${{ github.ref_name == 'main' }}
+      - name: Install
+        run: rustup target add ${{ matrix.settings.target }}
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         if: ${{ contains(matrix.settings.target, 'musl') }}
         with:
@@ -174,6 +177,7 @@ jobs:
         if: matrix.settings.target == 'i686-pc-windows-msvc'
         with:
           node-version: 22
+          package-manager-cache: false
           architecture: x86
       - name: Build
         run: ${{ matrix.settings.build }}
@@ -282,6 +286,7 @@ jobs:
           node-version: ${{ matrix.node }}
           check-latest: true
           architecture: ${{ matrix.settings.architecture }}
+          package-manager-cache: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: cli
@@ -335,6 +340,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node }}
+          package-manager-cache: false
       - name: Output docker params
         id: docker
         run: |
@@ -406,6 +412,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
+          package-manager-cache: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: cli
@@ -446,6 +453,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
+          package-manager-cache: false
       - name: Install dependencies
         run: pnpm install
       - name: Download all artifacts

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -173,7 +173,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Pin cargo binary
-        run: echo "CARGO=$(rustup which cargo)" >> "$GITHUB_ENV"
+        shell: bash
+        run: |
+          CARGO_PATH="$(rustup which cargo)"
+          echo "CARGO=$CARGO_PATH" >> "$GITHUB_ENV"
+          dirname "$CARGO_PATH" >> "$GITHUB_PATH"
       - name: Setup node x86
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         if: matrix.settings.target == 'i686-pc-windows-msvc'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,4 +21,5 @@ jobs:
     name: Security Analysis
     runs-on: ubuntu-slim
     steps:
+      - uses: oxc-project/setup-rust@23f38cfb0c04af97a055f76acee94d5be71c7c82 # v1.0.16
       - uses: oxc-project/security-action@77e230508eccbb400b23746dab6c573a8ea7483e # v1.0.5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
   "fmt",
 ] } # Omit the `regex` feature
 
-[target.'cfg(all(not(target_os = "linux"), not(target_os = "freebsd"), not(target_arch = "arm"), not(target_arch = "x86"), not(target_family = "wasm")))'.dependencies]
+[target.'cfg(all(not(target_os = "linux"), not(target_os = "freebsd"), not(target_arch = "arm"), not(target_arch = "x86"), not(target_family = "wasm"), not(all(target_os = "windows", target_arch = "aarch64"))))'.dependencies]
 mimalloc-safe = { version = "0.1", features = ["skip_collect_on_exit"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]

--- a/package.json
+++ b/package.json
@@ -36,5 +36,5 @@
       "oxlint --fix"
     ]
   },
-  "packageManager": "pnpm@10.33.0"
+  "packageManager": "pnpm@11.0.4"
 }

--- a/packages/integrate-ava/package.json
+++ b/packages/integrate-ava/package.json
@@ -11,9 +11,9 @@
   },
   "ava": {
     "cache": false,
-    "extensions": {
-      "ts": "module"
-    },
+    "extensions": [
+      "ts"
+    ],
     "files": [
       "__tests__/**/*.spec.ts"
     ],

--- a/packages/integrate-module-bundler/package.json
+++ b/packages/integrate-module-bundler/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --enable-source-maps --import @oxc-node/core/register --conditions=dev ./src/index.ts"
+    "test": "node ../cli/dist/index.js -C dev ./src/index.ts"
   },
   "dependencies": {
     "file-type": "^22.0.0",

--- a/packages/integrate-module-bundler/package.json
+++ b/packages/integrate-module-bundler/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "oxnode -C dev ./src/index.ts"
+    "test": "node --enable-source-maps --import @oxc-node/core/register --conditions=dev ./src/index.ts"
   },
   "dependencies": {
     "file-type": "^22.0.0",

--- a/packages/integrate-module/package.json
+++ b/packages/integrate-module/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --enable-source-maps --import @oxc-node/core/register ./src/index.ts"
+    "test": "node ../cli/dist/index.js ./src/index.ts"
   },
   "dependencies": {
     "file-type": "^22.0.0",

--- a/packages/integrate-module/package.json
+++ b/packages/integrate-module/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "oxnode ./src/index.ts"
+    "test": "node --enable-source-maps --import @oxc-node/core/register ./src/index.ts"
   },
   "dependencies": {
     "file-type": "^22.0.0",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,11 @@
 packages:
   - packages/*
+allowBuilds:
+  '@nestjs/core': true
+  '@swc/core': true
+  core-js: true
+  esbuild: true
+  nx: true
 
 catalog:
   "@napi-rs/cli": 3.6.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,8 @@
 packages:
   - packages/*
 allowBuilds:
-  '@nestjs/core': true
-  '@swc/core': true
+  "@nestjs/core": true
+  "@swc/core": true
   core-js: true
   esbuild: true
   nx: true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -460,24 +460,6 @@ pub fn create_resolve<'env>(
         return add_short_circuit(specifier, Some("module"), context, next_resolve);
     }
 
-    let has_custom_conditions = context.conditions.iter().any(|condition| {
-        !matches!(
-            condition.as_str(),
-            "node" | "import" | "module-sync" | "node-addons" | "require" | "default"
-        )
-    });
-    if has_custom_conditions
-        && !specifier.starts_with('.')
-        && !specifier.starts_with('/')
-        && !specifier.starts_with(PATH_PREFIX)
-    {
-        tracing::debug!(
-            "delegating bare-specifier resolve with custom conditions: {}",
-            specifier
-        );
-        return next_resolve.call((specifier, None).into());
-    }
-
     #[cfg(target_family = "wasm")]
     let cwd = {
         if let Some(get_cwd) = options.get_current_directory {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,8 @@ use phf::Set;
 #[cfg(all(
     not(target_arch = "x86"),
     not(target_arch = "arm"),
-    not(target_family = "wasm")
+    not(target_family = "wasm"),
+    not(all(target_os = "windows", target_arch = "aarch64"))
 ))]
 #[global_allocator]
 static ALLOC: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;
@@ -457,6 +458,24 @@ pub fn create_resolve<'env>(
             return add_short_circuit(specifier, Some("json"), context, next_resolve);
         }
         return add_short_circuit(specifier, Some("module"), context, next_resolve);
+    }
+
+    let has_custom_conditions = context.conditions.iter().any(|condition| {
+        !matches!(
+            condition.as_str(),
+            "node" | "import" | "module-sync" | "node-addons" | "require" | "default"
+        )
+    });
+    if has_custom_conditions
+        && !specifier.starts_with('.')
+        && !specifier.starts_with('/')
+        && !specifier.starts_with(PATH_PREFIX)
+    {
+        tracing::debug!(
+            "delegating bare-specifier resolve with custom conditions: {}",
+            specifier
+        );
+        return next_resolve.call((specifier, None).into());
     }
 
     #[cfg(target_family = "wasm")]


### PR DESCRIPTION
## Summary
- update the pnpm package manager pin to `pnpm@11.0.4`
- add missing pnpm package manager metadata where needed
- keep lockfiles unchanged to avoid unrelated dependency updates