### PR TITLE
ci: bump cargo-shear to 1.13.1

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -19,12 +19,12 @@ jobs:
       - uses: oxc-project/setup-rust@3d6fb132fbe7cdcb66bf8ec193911c2945369d12 # v1.0.17
         with:
           restore-cache: false
-          tools: cargo-shear@1
+          tools: cargo-shear@1.13.1
           components: rustfmt
 
       - uses: oxc-project/setup-node@4c588e9266bd930b6ddc34307df0659ed511d187 # v1.3.1
 
-      - run: cargo shear --fix
+      - run: cargo shear --fix --check-test-targets
       - run: node --run fmt
 
       - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4


### PR DESCRIPTION
Bumps cargo-shear to 1.13.1 and runs cargo shear with `--check-test-targets`.