### PR TITLE
ci: fix WASI and Docker binding tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -176,7 +176,9 @@ jobs:
         shell: bash
         run: |
           CARGO_PATH="$(rustup which cargo)"
+          RUSTC_PATH="$(rustup which rustc)"
           echo "CARGO=$CARGO_PATH" >> "$GITHUB_ENV"
+          echo "RUSTC=$RUSTC_PATH" >> "$GITHUB_ENV"
           dirname "$CARGO_PATH" >> "$GITHUB_PATH"
       - name: Setup node x86
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -403,7 +405,7 @@ jobs:
         with:
           image: ${{ steps.docker.outputs.IMAGE }}
           options: -v ${{ steps.docker.outputs.PNPM_STORE_PATH }}:${{ steps.docker.outputs.PNPM_STORE_PATH }} -v ${{ github.workspace }}:${{ github.workspace }} -w ${{ github.workspace }} --platform ${{ steps.docker.outputs.PLATFORM }}
-          run: npm i -g corepack && corepack enable && pnpm test
+          run: npm i -g corepack && corepack enable && pnpm install --force && pnpm test
   test-wasi:
     name: Test WASI target
     needs:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,5 +21,4 @@ jobs:
     name: Security Analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: oxc-project/setup-rust@3d6fb132fbe7cdcb66bf8ec193911c2945369d12 # v1.0.17
       - uses: oxc-project/security-action@2ac862d109c9728f5bf439d249b69f68905a5de4 # v1.0.8


### PR DESCRIPTION
Pin the absolute Rust compiler path for WASI builds so napi-build can locate the Rust target startup object, and refresh pnpm dependencies inside Docker binding checks before running the suite.