### PR TITLE
chore: set root crate license to MIT

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "oxc-node"
 version = "0.0.0"
 authors = ["LongYinan <github@lyn.one>"]
 edition = "2024"
+license = "MIT"
 publish = false
 
 [lib]


### PR DESCRIPTION
The root `oxc-node` crate has no `license` field in `Cargo.toml`, so `cargo deny` (run by the **Security Analysis** workflow) now fails it as `unlicensed`:

```
warning[no-license-field]: license expression was not specified in manifest for crate 'oxc-node = 0.0.0'
error[unlicensed]: oxc-node = 0.0.0 is unlicensed
...
advisories ok, bans ok, licenses FAILED, sources ok
```

This started failing across branches today (the action installs `cargo-deny` fresh, and it now errors on the pre-existing missing field). Declaring the license fixes it repo-wide.

`MIT` matches the license already published for `@oxc-node/core` and `@oxc-node/cli`.

```toml
[package]
name = "oxc-node"
version = "0.0.0"
authors = ["LongYinan <github@lyn.one>"]
edition = "2024"
license = "MIT"
publish = false
```

Only `Cargo.toml` changes — `Cargo.lock` is unaffected. `cargo metadata` confirms the crate now resolves with `"license":"MIT"`.
