### PR TITLE
chore: exclude @oxc-project/* from pnpm minimum release age gate

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,3 +12,6 @@ catalog:
   vite-plus: 0.2.2
 
 verifyDepsBeforeRun: install
+
+minimumReleaseAgeExclude:
+  - "@oxc-project/*"


### PR DESCRIPTION
## What

Add `@oxc-project/*` to `minimumReleaseAgeExclude` in `pnpm-workspace.yaml`.

## Why

pnpm 11.9 enforces a 24h supply-chain cooldown (`minimumReleaseAge: 1440`, on by default — it's not set anywhere in the repo). Renovate oxc PRs bump `@oxc-project/runtime` to a release that is typically only hours old, so `pnpm install` fails the policy check:

```
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 1 lockfile entries failed verification:
  @oxc-project/runtime@0.139.0 was published at 2026-07-06T15:28:20.000Z, within the minimumReleaseAge cutoff
```

(see the failing run on #670).

vite-plus (`vp config`) already seeds this list with the `oxlint`/`oxfmt`/`vitest` families but not `@oxc-project/*`. This is the only registry-sourced oxc package in the workspace — the `@oxc-node/*` packages are `workspace:*` and never gated. A full `pnpm install` (which runs `vp config`) leaves the entry intact.

Verified locally against the #670 bump with a fresh, cache-cleared check: without the exclude the lockfile fails with the violation above; with it, `✓ Lockfile passes supply-chain policies`.