### PR TITLE
ci: drop redundant global npm install before pnpm publish

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -475,7 +475,6 @@ jobs:
           path: ./packages/cli/dist
       - name: Publish
         run: |
-          npm install -g npm
           if git log -1 --pretty=%B | grep "^v\?[0-9]\+\.[0-9]\+\.[0-9]\+$";
           then
             pnpm napi pre-publish -t npm --package-json-path packages/core/package.json


### PR DESCRIPTION
Removes the redundant `npm install -g npm` step from the publish job. Publishing already uses `pnpm publish`, so the globally-installed npm version has no effect and the step can be dropped.