### PR TITLE
chore: reduce Rust dev debug info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,9 @@ napi-build = "2"
 codegen-units = 1
 lto = true
 strip = "symbols"
+
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+debug = false


### PR DESCRIPTION
Reduces debug information for local Rust builds and disables debug information for dependencies.